### PR TITLE
Add authentication to sessions chat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.12-slim
 WORKDIR /app
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir --index-url https://packagefeedproxy.microsoft.io/pypi/simple/ -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # Dockerfile for Azure Container App with AutoGen and Azure OpenAI
-FROM python:3.10-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --index-url https://packagefeedproxy.microsoft.io/pypi/simple/ -r requirements.txt
 
 COPY . .
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The application is a Flask-based web interface that leverages **Microsoft Agent 
                     ▼                  ▼
     ┌──────────────────────┐  ┌─────────────────────────────┐
     │  Azure OpenAI        │  │  Dynamic Session Pool       │
-    │  - GPT-4o-mini       │  │  (Custom Containers)        │
+    │  - GPT-5.6-sol       │  │  (Custom Containers)        │
     │  - Agent LLM         │  │                             │
     └──────────────────────┘  │  ┌───────────────────────┐  │
                               │  │ Session Container     │  │
@@ -52,7 +52,7 @@ The application is a Flask-based web interface that leverages **Microsoft Agent 
 - **Custom Container Sessions**: Primary feature using Azure Container Apps dynamic sessions with custom Docker containers for secure Python code execution
 - **Pre-installed Libraries**: Custom container includes numpy, pandas, matplotlib, and data file format support (openpyxl, xlrd, pyarrow, lxml)
 - **Microsoft Agent Framework**: Next-generation AI orchestration with intelligent tool selection
-- **Azure OpenAI Integration**: GPT-4o-mini model with managed identity authentication
+- **Azure OpenAI Integration**: GPT-5.6-sol model with managed identity authentication
 - **Interactive Web UI**: Modern chat interface with session tracking and code execution visualization
 - **Secure Isolated Execution**: Each code execution runs in a separate, secure Hyper-V isolated container
 - **Session Management**: Automatic lifecycle tracking with visual session status indicators
@@ -155,6 +155,94 @@ If you prefer manual configuration, set:
 - `AZURE_CONTAINER_APPS_SESSION_POOL_ENDPOINT`
 - `SESSION_POOL_AUDIENCE` (defaults to `https://dynamicsessions.io/.default`)
 
+### 2b. Configure Chat Authentication (Recommended: Microsoft Entra)
+
+This sample now supports validating Microsoft Entra access tokens directly on `/api/chat/`. This is the recommended production approach because it gives per-caller identity and policy control.
+
+#### Create the Entra app registration (secretless browser sign-in + API audience)
+
+Use these settings when creating the app registration in Microsoft Entra ID.
+
+1. App registration basics:
+  - Name: `dynamic-sessions-custom-container-web`
+  - Supported account types: `Accounts in this organizational directory only (Single tenant)`
+
+2. Authentication:
+  - Platform: `Single-page application (SPA)`
+  - Redirect URI:
+    - `https://<your-container-app-fqdn>/`
+  - Do not create a client secret (this flow uses PKCE).
+  - Do not add this callback under the `Web` platform. The callback must appear under `Single-page application` so Entra permits browser token redemption.
+
+3. Expose an API:
+  - Application ID URI:
+    - `api://<APPLICATION_CLIENT_ID>`
+  - Add scope:
+    - Scope name: `access_as_user`
+    - Who can consent: `Admins and users`
+
+4. Record these values (you will use them below):
+  - Tenant ID
+  - Application (client) ID
+  - Application ID URI (for example `api://<client-id>`)
+
+#### Configure the app for secretless browser sign-in
+
+Set these app environment variables on the container app:
+
+- `CHAT_AUTH_TENANT_ID=<tenant-guid>`
+- `CHAT_AUTH_AUDIENCE=<api-app-client-id>`
+- `CHAT_AUTH_CLIENT_ID=<api-app-client-id>`
+- `CHAT_AUTH_SCOPE=api://<api-app-client-id>/access_as_user`
+- `ALLOW_UNAUTHENTICATED_CHAT=false`
+- `TRUST_EASYAUTH_HEADERS=false`
+
+Example:
+
+```bash
+az containerapp update \
+  --name <app-name> \
+  --resource-group <resource-group> \
+  --set-env-vars CHAT_AUTH_TENANT_ID=<tenant-guid> CHAT_AUTH_AUDIENCE=<api-app-client-id> CHAT_AUTH_CLIENT_ID=<api-app-client-id> CHAT_AUTH_SCOPE=api://<api-app-client-id>/access_as_user ALLOW_UNAUTHENTICATED_CHAT=false TRUST_EASYAUTH_HEADERS=false
+```
+
+#### Smoke test
+
+1. Open the app URL.
+2. Send a chat message.
+3. The app should show a Sign In button and open Microsoft Entra login.
+4. After sign-in, `/api/chat/` requests should succeed.
+
+Token-validation environment variables used by the backend and browser PKCE flow:
+
+- `CHAT_AUTH_TENANT_ID`: Your Entra tenant GUID. If omitted, the app falls back to `AZURE_TENANT_ID`.
+- `CHAT_AUTH_AUDIENCE`: Expected token audience for your API. For Microsoft Entra v2 access tokens, use the API app registration client ID GUID (for example, `<app-registration-client-id>`).
+- `CHAT_AUTH_CLIENT_ID`: Entra app client ID used by browser OAuth sign-in.
+- `CHAT_AUTH_SCOPE`: Scope requested by browser PKCE flow (default: `<CHAT_AUTH_AUDIENCE>/access_as_user`).
+
+Example (Azure Container Apps):
+
+```bash
+az containerapp update \
+  --name <app-name> \
+  --resource-group <resource-group> \
+  --set-env-vars CHAT_AUTH_TENANT_ID=<tenant-guid> CHAT_AUTH_AUDIENCE=<api-app-client-id>
+```
+
+Get a caller token for local testing:
+
+```bash
+az login
+az account get-access-token --scope api://<api-app-client-id>/.default --query accessToken -o tsv
+```
+
+Authorize callers using Entra app roles or group membership. Keep managed identity RBAC least-privileged for outbound calls to Azure OpenAI and the session pool.
+
+Fallback options (not recommended for production):
+
+- Trusted platform headers: set `TRUST_EASYAUTH_HEADERS=true` only when your hosting platform guarantees those headers are injected and stripped from external requests.
+- `ALLOW_UNAUTHENTICATED_CHAT=true` for local-only quick testing.
+
 ### 3. Run Locally
 
 ```bash
@@ -199,7 +287,22 @@ Session Pool: Returns "1,904.93..." (remembers previous calculation)
 
 ### Chat Endpoint
 
-**POST** `/chat`
+**POST** `/api/chat/`
+
+Authentication header (required unless EasyAuth or `ALLOW_UNAUTHENTICATED_CHAT=true` is used):
+
+```http
+Authorization: Bearer <ENTRA_ACCESS_TOKEN>
+```
+
+Example request:
+
+```bash
+curl -X POST "http://localhost:8080/api/chat/" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ENTRA_ACCESS_TOKEN" \
+  -d '{"prompt":"Calculate the mean of [1,2,3,4,5]","session_id":"user_123"}'
+```
 
 ```json
 {
@@ -214,7 +317,7 @@ Response:
 {
   "response": "I've calculated that for you.",
   "agent": "Microsoft Agent Framework SmartAssistant",
-  "model": "gpt-4o-mini",
+  "model": "gpt-5.6-sol",
   "tools_used": [
     {
       "name": "execute_in_dynamic_session",
@@ -255,7 +358,7 @@ The web interface demonstrates custom container sessions:
 
 ### Azure OpenAI Integration
 
-- **GPT-4o-mini model**: Fast and efficient for agent orchestration and code generation
+- **GPT-5.6-sol model**: Fast and efficient for agent orchestration and code generation
 - **Managed identity**: Keyless authentication for secure service-to-service communication
 - **Automatic code detection**: Identifies when Python execution is needed for math/calculations
 
@@ -310,7 +413,9 @@ hooks:
 
 Key parameters in `infra/main.bicep`:
 
-- `openAIModelName`: GPT model to deploy (default: gpt-4o-mini)
+- `openAIModelName`: GPT model to deploy (default: gpt-5.6-sol)
+- `openAIModelVersion`: Model version to deploy (default: 2026-07-09)
+- `openAIDeploymentSkuName`: Deployment SKU for the model (default: GlobalStandard)
 - `maxConcurrentSessions`: Maximum parallel sessions (default: 10)
 - `readySessionInstances`: Pre-warmed sessions for fast response (default: 5)
 - `enableVNetIntegration`: Enable private networking (default: false)
@@ -326,7 +431,7 @@ The custom session container (`session-container/Dockerfile`) includes:
 
 ## Resources Deployed
 
-- **Azure OpenAI Service**: GPT-4o-mini deployment for agent intelligence
+- **Azure OpenAI Service**: GPT-5.6-sol deployment for agent intelligence
 - **Container Apps Environment**: Serverless hosting platform
 - **Dynamic Session Pool**: Custom container execution environment
 - **Container Registry**: Stores custom session container image

--- a/docs/MANAGED-IDENTITY.md
+++ b/docs/MANAGED-IDENTITY.md
@@ -137,7 +137,7 @@ The application uses these environment variables (no secrets required):
 ```bash
 # Azure OpenAI Configuration
 AZURE_OPENAI_ENDPOINT="https://<your-openai-name>.openai.azure.com/"
-AZURE_OPENAI_DEPLOYMENT="gpt-4o-mini"
+AZURE_OPENAI_DEPLOYMENT="gpt-5.6-sol"
 
 # Session Pool Configuration
 AZURE_CONTAINER_APPS_SESSION_POOL_ENDPOINT="https://<your-session-pool-name>.<environment-unique-id>.<region>.azurecontainerapps.io"

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -41,7 +41,7 @@ Use the "Start Agent Framework Server" task in VS Code (Terminal → Run Task)
 ```bash
 # Set environment variables (optional for demo mode)
 $env:AZURE_OPENAI_ENDPOINT = "https://your-resource.openai.azure.com/"
-$env:AZURE_OPENAI_DEPLOYMENT = "gpt-4o-mini"
+$env:AZURE_OPENAI_DEPLOYMENT = "gpt-5.6-sol"
 $env:SESSION_POOL_ENDPOINT = "https://your-session-pool.azurecontainerapps.io"
 $env:SESSION_POOL_AUDIENCE = "https://dynamicsessions.io/.default"
 
@@ -74,7 +74,7 @@ curl http://localhost:8080/api/system/health
   "status": "healthy",
   "azure_openai_configured": true,
   "session_pool_configured": true,
-  "model": "gpt-4o-mini",
+  "model": "gpt-5.6-sol",
   "timestamp": "2025-12-07T12:34:56.789Z"
 }
 ```

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -8,10 +8,24 @@ param environmentName string = 'dev'
 param location string = 'eastus'
 
 @description('Azure OpenAI model name to deploy')
-param openAIModelName string = 'gpt-4o-mini'
+param openAIModelName string = 'gpt-5.6-sol'
 
 @description('Azure OpenAI model version to deploy')
-param openAIModelVersion string = '2024-07-18'
+param openAIModelVersion string = '2026-07-09'
+
+@allowed([
+  'Standard'
+  'GlobalStandard'
+  'DataZoneStandard'
+  'ProvisionedManaged'
+  'GlobalProvisionedManaged'
+  'DataZoneProvisionedManaged'
+  'GlobalBatch'
+  'DataZoneBatch'
+  'DeveloperTier'
+])
+@description('Azure OpenAI deployment SKU name. Must be supported by the selected model/version in the target region.')
+param openAIDeploymentSkuName string = 'GlobalStandard'
 
 @description('Azure OpenAI deployment capacity')
 param openAICapacity int = 30
@@ -33,6 +47,34 @@ param readySessionInstances int = 5
 
 @description('Enable VNet integration for Container Apps Environment')
 param enableVNetIntegration bool = false
+
+@description('Enable Entra sign-in via Container Apps authentication')
+param enableEntraAuth bool = false
+
+@description('Entra tenant ID used by Container Apps authentication')
+param entraTenantId string = ''
+
+@description('Entra app registration client ID used by Container Apps authentication')
+param entraClientId string = ''
+
+@secure()
+@description('Entra app registration client secret used by Container Apps authentication')
+param entraClientSecret string = ''
+
+@description('Tenant ID used by backend bearer token validation')
+param chatAuthTenantId string = ''
+
+@description('Expected audience used by backend bearer token validation')
+param chatAuthAudience string = ''
+
+@description('Entra app registration client ID used by browser sign-in (MSAL)')
+param chatAuthClientId string = ''
+
+@description('Scope requested by browser sign-in (MSAL)')
+param chatAuthScope string = ''
+
+@description('Allow anonymous access to /api/chat (not recommended for production)')
+param allowUnauthenticatedChat bool = false
 
 @description('VNet address prefix')
 param vnetAddressPrefix string = '10.0.0.0/16'
@@ -112,7 +154,7 @@ resource gptModelDeployment 'Microsoft.CognitiveServices/accounts/deployments@20
     raiPolicyName: 'Microsoft.Default'
   }
   sku: {
-    name: 'Standard'
+    name: openAIDeploymentSkuName
     capacity: openAICapacity
   }
 }
@@ -376,6 +418,30 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'SESSION_POOL_AUDIENCE'
               value: 'https://dynamicsessions.io/.default'
             }
+            {
+              name: 'CHAT_AUTH_TENANT_ID'
+              value: chatAuthTenantId
+            }
+            {
+              name: 'CHAT_AUTH_AUDIENCE'
+              value: chatAuthAudience
+            }
+            {
+              name: 'CHAT_AUTH_CLIENT_ID'
+              value: chatAuthClientId
+            }
+            {
+              name: 'CHAT_AUTH_SCOPE'
+              value: chatAuthScope
+            }
+            {
+              name: 'ALLOW_UNAUTHENTICATED_CHAT'
+              value: allowUnauthenticatedChat ? 'true' : 'false'
+            }
+            {
+              name: 'TRUST_EASYAUTH_HEADERS'
+              value: (enableEntraAuth && !empty(entraClientId) && !empty(entraTenantId) && !empty(entraClientSecret)) ? 'true' : 'false'
+            }
           ]
         }
       ]
@@ -390,6 +456,28 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
     openAIUserRoleAssignment
     gptModelDeployment
   ]
+}
+
+resource containerAppAuth 'Microsoft.App/containerApps/authConfigs@2024-03-01' = if (enableEntraAuth && !empty(entraClientId) && !empty(entraClientSecret) && !empty(entraTenantId)) {
+  parent: containerApp
+  name: 'current'
+  properties: {
+    platform: {
+      enabled: true
+    }
+    globalValidation: {
+      unauthenticatedClientAction: 'AllowAnonymous'
+    }
+    identityProviders: {
+      azureActiveDirectory: {
+        enabled: true
+        registration: {
+          clientId: entraClientId
+          openIdIssuer: 'https://login.microsoftonline.com/${entraTenantId}/v2.0'
+        }
+      }
+    }
+  }
 }
 
 // Outputs for deployment information

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -13,6 +13,30 @@
     },
     "principalId": {
       "value": "${AZURE_PRINCIPAL_ID}"
+    },
+    "chatAuthTenantId": {
+      "value": "${CHAT_AUTH_TENANT_ID}"
+    },
+    "chatAuthAudience": {
+      "value": "${CHAT_AUTH_AUDIENCE}"
+    },
+    "chatAuthClientId": {
+      "value": "${CHAT_AUTH_CLIENT_ID}"
+    },
+    "chatAuthScope": {
+      "value": "${CHAT_AUTH_SCOPE}"
+    },
+    "allowUnauthenticatedChat": {
+      "value": "${ALLOW_UNAUTHENTICATED_CHAT=false}"
+    },
+    "enableEntraAuth": {
+      "value": "${ENABLE_ENTRA_AUTH=false}"
+    },
+    "entraTenantId": {
+      "value": "${ENTRA_TENANT_ID}"
+    },
+    "entraClientId": {
+      "value": "${ENTRA_CLIENT_ID}"
     }
   }
 }

--- a/main.py
+++ b/main.py
@@ -10,29 +10,16 @@ import queue
 from datetime import datetime, timedelta
 from flask import Flask, request, jsonify, send_file, Response, stream_with_context
 from flask_restx import Api, Resource, fields, Namespace
-from agent_framework import ChatAgent, AgentThread
-try:
-    from agent_framework import ai_function
-except ImportError:
-    try:
-        from agent_framework.tools import ai_function
-    except ImportError:
-        try:
-            from agent_framework.decorators import ai_function
-        except ImportError:
-            try:
-                from agent_framework import tool as ai_function
-            except ImportError:
-                def ai_function(func=None, **_kwargs):
-                    def decorator(f):
-                        return f
-                    return decorator(func) if func else decorator
-from agent_framework.azure import AzureOpenAIChatClient
+from agent_framework import Agent, AgentSession
+from agent_framework import tool as ai_function
+from agent_framework.openai import OpenAIChatClient
 from azure.identity import DefaultAzureCredential
 from typing import Annotated, List, Dict, Any, Optional
 from pydantic import Field
 import requests
 import aiohttp
+import jwt
+from jwt import InvalidTokenError
 
 app = Flask(__name__)
 
@@ -121,11 +108,105 @@ RESOURCE_GROUP = os.getenv("AZURE_RESOURCE_GROUP")
 SESSION_POOL_NAME = os.getenv("AZURE_SESSION_POOL_NAME", "dynamic-session-pool")
 SESSION_POOL_AUDIENCE = os.getenv("SESSION_POOL_AUDIENCE", "https://dynamicsessions.io/.default")
 
+# Chat endpoint authentication settings
+ALLOW_UNAUTHENTICATED_CHAT = os.getenv("ALLOW_UNAUTHENTICATED_CHAT", "false").lower() in ("1", "true", "yes")
+TRUST_EASYAUTH_HEADERS = os.getenv("TRUST_EASYAUTH_HEADERS", "false").lower() in ("1", "true", "yes")
+CHAT_AUTH_TENANT_ID = os.getenv("CHAT_AUTH_TENANT_ID") or os.getenv("AZURE_TENANT_ID", "")
+CHAT_AUTH_AUDIENCE = os.getenv("CHAT_AUTH_AUDIENCE", "")
+CHAT_AUTH_CLIENT_ID = os.getenv("CHAT_AUTH_CLIENT_ID", "")
+CHAT_AUTH_SCOPE = os.getenv("CHAT_AUTH_SCOPE", f"{CHAT_AUTH_AUDIENCE}/access_as_user" if CHAT_AUTH_AUDIENCE else "")
+
+_entra_jwks_clients: Dict[str, Any] = {}
+
 # Session management storage
 active_sessions: Dict[str, Dict[str, Any]] = {}
 
 # Track which session IDs have been used in current request to avoid duplicates
 current_request_sessions: set = set()
+
+
+def _extract_bearer_token(auth_header: str) -> str:
+    if not auth_header:
+        return ""
+    parts = auth_header.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return ""
+    return parts[1].strip()
+
+
+def _get_entra_jwks_client(tenant_id: str) -> Any:
+    if tenant_id not in _entra_jwks_clients:
+        jwks_url = f"https://login.microsoftonline.com/{tenant_id}/discovery/v2.0/keys"
+        _entra_jwks_clients[tenant_id] = jwt.PyJWKClient(jwks_url)
+    return _entra_jwks_clients[tenant_id]
+
+
+def _has_valid_entra_bearer_token() -> bool:
+    if not CHAT_AUTH_TENANT_ID or not CHAT_AUTH_AUDIENCE:
+        return False
+
+    presented_token = _extract_bearer_token(request.headers.get("Authorization", ""))
+    if not presented_token:
+        return False
+
+    try:
+        jwks_client = _get_entra_jwks_client(CHAT_AUTH_TENANT_ID)
+        signing_key = jwks_client.get_signing_key_from_jwt(presented_token).key
+        expected_audiences = [CHAT_AUTH_AUDIENCE]
+        if CHAT_AUTH_CLIENT_ID and CHAT_AUTH_CLIENT_ID not in expected_audiences:
+            expected_audiences.append(CHAT_AUTH_CLIENT_ID)
+
+        claims = jwt.decode(
+            presented_token,
+            signing_key,
+            algorithms=["RS256"],
+            audience=expected_audiences,
+            options={"require": ["iss", "aud", "exp"]}
+        )
+
+        valid_issuers = {
+            f"https://login.microsoftonline.com/{CHAT_AUTH_TENANT_ID}/v2.0",
+            f"https://sts.windows.net/{CHAT_AUTH_TENANT_ID}/"
+        }
+        if claims.get("iss") not in valid_issuers:
+            return False
+
+        # Require a caller identity claim so only authenticated principals are accepted.
+        return bool(claims.get("oid") or claims.get("sub"))
+    except InvalidTokenError as token_error:
+        print(f"❌ Chat auth token validation failed: {token_error}")
+        return False
+    except Exception as auth_error:
+        print(f"❌ Chat auth processing error: {auth_error}")
+        return False
+
+
+def _has_trusted_easyauth_identity() -> bool:
+    if not TRUST_EASYAUTH_HEADERS:
+        return False
+
+    principal_id = request.headers.get("X-MS-CLIENT-PRINCIPAL-ID", "")
+    principal_provider = request.headers.get("X-MS-CLIENT-PRINCIPAL-IDP", "")
+    return bool(principal_id) and principal_provider.lower() in ("aad", "entra")
+
+
+def _is_authenticated_chat_request() -> bool:
+    if ALLOW_UNAUTHENTICATED_CHAT:
+        return True
+    if _has_valid_entra_bearer_token():
+        return True
+    if _has_trusted_easyauth_identity():
+        return True
+    return False
+
+
+@app.before_request
+def require_auth_for_chat_endpoints():
+    if request.path.startswith("/api/chat") and not _is_authenticated_chat_request():
+        return jsonify({
+            "error": "Authentication required for chat endpoints",
+            "details": "Provide a valid Microsoft Entra Bearer token for CHAT_AUTH_AUDIENCE, or configure trusted platform authentication."
+        }), 401
 
 # Enhanced AI functions (tools) for the agent
 @ai_function
@@ -464,8 +545,8 @@ agent = None
 if AZURE_OPENAI_ENDPOINT:
     try:
         # Create Agent Framework client with managed identity - following official docs pattern
-        chat_client = AzureOpenAIChatClient(
-            deployment_name=AZURE_OPENAI_DEPLOYMENT,
+        chat_client = OpenAIChatClient(
+            model=AZURE_OPENAI_DEPLOYMENT,
             azure_endpoint=AZURE_OPENAI_ENDPOINT,
             credential=DefaultAzureCredential()
         )
@@ -507,8 +588,8 @@ Always think step-by-step about which tools will best serve the user's needs."""
                 tools=tools
             )
         else:
-            agent = ChatAgent(
-                chat_client=chat_client,
+            agent = Agent(
+                client=chat_client,
                 instructions=instructions,
                 name="SmartAssistant",
                 tools=tools
@@ -747,6 +828,12 @@ def index():
         .send-button:hover {
             background: #0056b3;
         }
+        .secondary-button {
+            background: #6c757d;
+        }
+        .secondary-button:hover {
+            background: #545b62;
+        }
         .send-button:disabled {
             background: #6c757d;
             cursor: not-allowed;
@@ -826,7 +913,7 @@ def index():
         </div>
         
         <div class="tools-info">
-            <strong>Available Tools:</strong> Tool Discovery 🔧 | Python Execution 📦 | <a href="/docs/" target="_blank" style="color: #007bff;">📖 API Docs</a>
+            <strong>Available Tools:</strong> Tool Discovery 🔧 | Python Execution 📦 | <a href="/docs/" style="color: #007bff;">📖 API Docs</a>
         </div>
         
         <div class="chat-container" id="chatContainer">
@@ -837,6 +924,7 @@ def index():
         
         <div class="input-container">
             <input type="text" id="messageInput" class="input-field" placeholder="Ask me to execute Python code or discover tools..." onkeypress="handleKeyPress(event)">
+            <button id="loginButton" class="send-button secondary-button" onclick="handleLoginClick()" style="display: none;">Sign In</button>
             <button id="sendButton" class="send-button" onclick="sendMessage()">Send</button>
         </div>
     </div>
@@ -853,6 +941,220 @@ def index():
         const chatContainer = document.getElementById('chatContainer');
         const messageInput = document.getElementById('messageInput');
         const sendButton = document.getElementById('sendButton');
+        const loginButton = document.getElementById('loginButton');
+
+        let authRuntimeConfig = null;
+        const TOKEN_STORAGE_KEY = 'entra_access_token';
+        const TOKEN_EXPIRY_STORAGE_KEY = 'entra_access_token_expiry';
+        const PKCE_VERIFIER_KEY = 'entra_pkce_verifier';
+        const PKCE_STATE_KEY = 'entra_pkce_state';
+
+        async function loadAuthConfig() {
+            try {
+                const response = await fetch('/api/system/auth-config', {
+                    method: 'GET',
+                    headers: { 'Content-Type': 'application/json' }
+                });
+                if (!response.ok) {
+                    return null;
+                }
+                return await response.json();
+            } catch (_error) {
+                return null;
+            }
+        }
+
+        function isBrowserAuthEnabled() {
+            return !!(
+                authRuntimeConfig &&
+                authRuntimeConfig.enabled &&
+                authRuntimeConfig.client_id &&
+                authRuntimeConfig.tenant_id &&
+                authRuntimeConfig.scope
+            );
+        }
+
+        function hasValidAccessToken() {
+            const token = sessionStorage.getItem(TOKEN_STORAGE_KEY);
+            const expiry = Number(sessionStorage.getItem(TOKEN_EXPIRY_STORAGE_KEY) || '0');
+            if (!token || !expiry) {
+                return false;
+            }
+            return Date.now() < expiry;
+        }
+
+        function updateLoginButton() {
+            if (!loginButton) {
+                return;
+            }
+            if (!isBrowserAuthEnabled()) {
+                loginButton.style.display = 'none';
+                return;
+            }
+
+            loginButton.style.display = 'inline-block';
+            loginButton.textContent = hasValidAccessToken() ? 'Sign Out' : 'Sign In';
+        }
+
+        async function toBase64Url(arrayBuffer) {
+            const bytes = new Uint8Array(arrayBuffer);
+            let binary = '';
+            for (let i = 0; i < bytes.length; i++) {
+                binary += String.fromCharCode(bytes[i]);
+            }
+            return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+        }
+
+        function randomString(length = 64) {
+            const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
+            const random = new Uint8Array(length);
+            crypto.getRandomValues(random);
+            let out = '';
+            for (let i = 0; i < length; i++) {
+                out += chars[random[i] % chars.length];
+            }
+            return out;
+        }
+
+        async function beginPkceLogin() {
+            const tenant = authRuntimeConfig.tenant_id;
+            const clientId = authRuntimeConfig.client_id;
+            const redirectUri = window.location.origin + '/';
+            const scope = `${authRuntimeConfig.scope} openid profile`;
+
+            const codeVerifier = randomString(96);
+            const state = randomString(40);
+            const challengeBuffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(codeVerifier));
+            const codeChallenge = await toBase64Url(challengeBuffer);
+
+            sessionStorage.setItem(PKCE_VERIFIER_KEY, codeVerifier);
+            sessionStorage.setItem(PKCE_STATE_KEY, state);
+
+            const authorizeUrl = new URL(`https://login.microsoftonline.com/${tenant}/oauth2/v2.0/authorize`);
+            authorizeUrl.searchParams.set('client_id', clientId);
+            authorizeUrl.searchParams.set('response_type', 'code');
+            authorizeUrl.searchParams.set('redirect_uri', redirectUri);
+            authorizeUrl.searchParams.set('response_mode', 'query');
+            authorizeUrl.searchParams.set('scope', scope);
+            authorizeUrl.searchParams.set('state', state);
+            authorizeUrl.searchParams.set('code_challenge', codeChallenge);
+            authorizeUrl.searchParams.set('code_challenge_method', 'S256');
+
+            window.location.href = authorizeUrl.toString();
+        }
+
+        async function redeemAuthorizationCode(code, state) {
+            const expectedState = sessionStorage.getItem(PKCE_STATE_KEY);
+            const codeVerifier = sessionStorage.getItem(PKCE_VERIFIER_KEY);
+
+            if (!expectedState || !codeVerifier || state !== expectedState) {
+                throw new Error('Invalid sign-in state');
+            }
+
+            const tenant = authRuntimeConfig.tenant_id;
+            const clientId = authRuntimeConfig.client_id;
+            const redirectUri = window.location.origin + '/';
+
+            const tokenUrl = `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token`;
+            const body = new URLSearchParams();
+            body.set('client_id', clientId);
+            body.set('grant_type', 'authorization_code');
+            body.set('code', code);
+            body.set('redirect_uri', redirectUri);
+            body.set('code_verifier', codeVerifier);
+            body.set('scope', `${authRuntimeConfig.scope} openid profile`);
+
+            const response = await fetch(tokenUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: body.toString()
+            });
+
+            if (!response.ok) {
+                let errorMessage = 'Token exchange failed';
+                try {
+                    const errorPayload = await response.json();
+                    errorMessage = errorPayload.error_description || errorPayload.error || errorMessage;
+                } catch (_parseError) {
+                    // Keep the generic message when the identity provider does not return JSON.
+                }
+                throw new Error(errorMessage);
+            }
+
+            const payload = await response.json();
+            const expiresIn = Number(payload.expires_in || 3600);
+            const expiryMs = Date.now() + (expiresIn - 60) * 1000;
+
+            sessionStorage.setItem(TOKEN_STORAGE_KEY, payload.access_token);
+            sessionStorage.setItem(TOKEN_EXPIRY_STORAGE_KEY, String(expiryMs));
+
+            sessionStorage.removeItem(PKCE_VERIFIER_KEY);
+            sessionStorage.removeItem(PKCE_STATE_KEY);
+        }
+
+        function clearTokenState() {
+            sessionStorage.removeItem(TOKEN_STORAGE_KEY);
+            sessionStorage.removeItem(TOKEN_EXPIRY_STORAGE_KEY);
+            sessionStorage.removeItem(PKCE_VERIFIER_KEY);
+            sessionStorage.removeItem(PKCE_STATE_KEY);
+        }
+
+        async function initBrowserAuth() {
+            authRuntimeConfig = await loadAuthConfig();
+            if (!authRuntimeConfig || !authRuntimeConfig.enabled || !authRuntimeConfig.client_id || !authRuntimeConfig.tenant_id || !authRuntimeConfig.scope) {
+                updateLoginButton();
+                return;
+            }
+
+            try {
+                const params = new URLSearchParams(window.location.search);
+                const code = params.get('code');
+                const state = params.get('state');
+                if (code && state) {
+                    await redeemAuthorizationCode(code, state);
+
+                    const cleanUrl = new URL(window.location.href);
+                    cleanUrl.searchParams.delete('code');
+                    cleanUrl.searchParams.delete('state');
+                    cleanUrl.searchParams.delete('session_state');
+                    cleanUrl.searchParams.delete('error');
+                    cleanUrl.searchParams.delete('error_description');
+                    window.history.replaceState({}, document.title, cleanUrl.toString());
+                }
+            } catch (error) {
+                clearTokenState();
+                addMessage(`❌ Sign-in failed: ${error.message}`);
+            }
+
+            updateLoginButton();
+        }
+
+        async function handleLoginClick() {
+            if (!isBrowserAuthEnabled()) {
+                addMessage('🔒 Browser sign-in is not configured yet.');
+                return;
+            }
+
+            if (hasValidAccessToken()) {
+                clearTokenState();
+                updateLoginButton();
+                return;
+            }
+
+            await beginPkceLogin();
+        }
+
+        async function getAccessTokenForChat() {
+            if (!isBrowserAuthEnabled()) {
+                return null;
+            }
+
+            if (!hasValidAccessToken()) {
+                return null;
+            }
+
+            return sessionStorage.getItem(TOKEN_STORAGE_KEY);
+        }
 
         function addMessage(text, isUser = false, toolsUsed = null) {
             const messageDiv = document.createElement('div');
@@ -923,16 +1225,36 @@ def index():
             chatContainer.classList.add('loading');
 
             try {
+                let authorizationHeader = null;
+                if (authRuntimeConfig && authRuntimeConfig.enabled) {
+                    const accessToken = await getAccessTokenForChat();
+                    if (!accessToken) {
+                        addMessage('🔒 Sign-in required. Click Sign In, then try again.');
+                        return;
+                    }
+                    authorizationHeader = `Bearer ${accessToken}`;
+                }
+
                 const response = await fetch('/api/chat/', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
+                        ...(authorizationHeader ? { 'Authorization': authorizationHeader } : {}),
                     },
                     body: JSON.stringify({
                         prompt: message,
                         session_id: 'web_chat'
                     })
                 });
+
+                if (response.status === 401) {
+                    if (authRuntimeConfig && authRuntimeConfig.enabled) {
+                        addMessage('🔒 Your sign-in token was rejected. Please Sign Out and Sign In again.');
+                    } else {
+                        addMessage('🔒 Authentication required for chat endpoints. Configure browser Entra auth or platform auth.');
+                    }
+                    return;
+                }
 
                 const data = await response.json();
                 console.log('📥 Received response:', data);
@@ -1000,6 +1322,8 @@ def index():
         }
         
 
+        initBrowserAuth();
+
         // Focus input on load
         messageInput.focus();
     </script>
@@ -1012,11 +1336,12 @@ class Chat(Resource):
     @api.doc('chat_with_agent')
     @api.expect(chat_request_model)
     @api.marshal_with(chat_response_model, code=200)
+    @api.response(401, 'Unauthorized', error_response_model)
     @api.response(400, 'Bad Request', error_response_model)
     @api.response(500, 'Internal Server Error', error_response_model)
     def post(self):
         """Send a message to the AI agent and get a response with automatic tool selection"""
-        data = request.json
+        data = request.get_json(silent=True) or {}
         prompt = data.get("prompt", "")
         session_id = data.get("session_id", "default")
         
@@ -1035,7 +1360,7 @@ class Chat(Resource):
             
             # Get or create conversation thread for session continuity
             if session_id not in conversation_threads:
-                conversation_threads[session_id] = agent.get_new_thread()
+                conversation_threads[session_id] = agent.create_session(session_id=session_id)
             
             thread = conversation_threads[session_id]
             
@@ -1049,7 +1374,7 @@ class Chat(Resource):
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
             print(f"🤖 DEBUG: About to call agent.run() with prompt: {prompt[:50]}...")
-            result = loop.run_until_complete(agent.run(prompt, thread=thread))
+            result = loop.run_until_complete(agent.run(prompt, session=thread))
             loop.close()
             print(f"🤖 DEBUG: agent.run() completed")
             
@@ -1097,11 +1422,12 @@ class ChatStream(Resource):
     @api.doc('chat_stream')
     @api.expect(chat_request_model)
     @api.response(200, 'Success')
+    @api.response(401, 'Unauthorized', error_response_model)
     @api.response(400, 'Bad Request', error_response_model)
     @api.response(500, 'Internal Server Error', error_response_model)
     def post(self):
         """Stream responses from the AI agent in real-time (experimental)"""
-        data = request.json
+        data = request.get_json(silent=True) or {}
         prompt = data.get("prompt", "")
         session_id = data.get("session_id", "default")
         
@@ -1114,7 +1440,7 @@ class ChatStream(Resource):
             
             # Get or create conversation thread
             if session_id not in conversation_threads:
-                conversation_threads[session_id] = agent.get_new_thread()
+                conversation_threads[session_id] = agent.create_session(session_id=session_id)
             
             thread = conversation_threads[session_id]
             
@@ -1127,7 +1453,7 @@ class ChatStream(Resource):
 
                     async def collect_stream():
                         try:
-                            async for chunk in agent.run_stream(prompt, thread=thread):
+                            async for chunk in agent.run(prompt, session=thread, stream=True):
                                 if chunk.text:
                                     q.put(("data", chunk.text))
                                     print(f"📡 Streaming: {chunk.text}", end="", flush=True)
@@ -1203,6 +1529,19 @@ class TestSessionPayload(Resource):
             print(f"🔍 TEST DEBUG - Exception: {e}", flush=True)
             return {"error": str(e)}, 500
 
+@system_ns.route('/auth-config')
+class AuthConfig(Resource):
+    @api.doc('auth_config')
+    def get(self):
+        return {
+            "enabled": bool(CHAT_AUTH_CLIENT_ID and CHAT_AUTH_TENANT_ID and CHAT_AUTH_SCOPE),
+            "tenant_id": CHAT_AUTH_TENANT_ID,
+            "client_id": CHAT_AUTH_CLIENT_ID,
+            "audience": CHAT_AUTH_AUDIENCE,
+            "scope": CHAT_AUTH_SCOPE,
+            "platform_auth_enabled": TRUST_EASYAUTH_HEADERS
+        }
+
 @system_ns.route('/health')
 class Health(Resource):
     @api.doc('health_check')
@@ -1261,6 +1600,7 @@ class Tools(Resource):
 class SessionManager(Resource):
     @api.doc('clear_session')
     @api.response(200, 'Session cleared successfully')
+    @api.response(401, 'Unauthorized', error_response_model)
     @api.response(404, 'Session not found')
     def delete(self, session_id):
         """Clear conversation history for a specific session"""

--- a/main.py
+++ b/main.py
@@ -341,13 +341,11 @@ def execute_in_dynamic_session(
         print(f"🔗 Session URL: {session_url}")
         print(f"📋 Payload: {execution_payload}")
         try:
-            print(f"🚀 Making request to: {session_url}")
-            print(f"📋 Headers: {headers}")
+            print(f"🚀 Making authenticated request to: {session_url}")
             print(f"📦 Payload: {execution_payload}")
             
             response = requests.post(session_url, json=execution_payload, headers=headers, timeout=60)
             print(f"📊 Response Status: {response.status_code}")
-            print(f"📝 Response Headers: {dict(response.headers)}")
             print(f"📝 Response Body: {response.text}")
         except requests.exceptions.RequestException as req_error:
             print(f"❌ Request failed: {req_error}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ azure-mgmt-containerinstance
 azure-mgmt-resource
 requests
 aiohttp
+PyJWT[crypto]


### PR DESCRIPTION
This not only updates the sample so it works today (it wasn't because gpt-4o-mini isn't supported any more), it also adds authentication. With that, it instructs users how to create a backing Entra app, then uses that to validate the user's identity before allowing them to use chat.

You can try it here: https://agent-framework-ebnwqn7gf6eis.lemonrock-713020a7.eastus.azurecontainerapps.io/

<img width="1421" height="900" alt="image" src="https://github.com/user-attachments/assets/f3b94584-85f0-4d8d-9343-47752c433b7c" />
